### PR TITLE
Update ascot-axum devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,57 +4,8 @@ The `Ascot Firmware` is a REST server developed with the `Ascot` interface,
 which provides a series of abstractions to interact with the commands defined
 on a smart home device.
 Through `REST` APIs, the server can run tasks on a device, retrieve some
-of its data, or change some of its properties. The device implemented in this
-example is a light.
+of its data, or change some of its properties. 
 
-The light is discoverable within the network through a `mDNS-SD` service.
+The device is discoverable within the network through a `mDNS-SD` service.
 
-## Building
-
-Run the command
-
-```console
-cargo build
-```
-
-## Running the server
-
-The server runs on `localhost` and listens to port `3000`. To make it run:
-
-```console
-cargo run
-```
-
-## REST API examples
-
-Through `curl` or a web browser, it is possible to call the APIs which perform
-some actions on a device.
-
-**Turn a light on**
-
-```console
-curl -X PUT 127.0.0.1:3000/light/on
-```
-
-**Turn a light off**
-
-```console
-curl -X PUT 127.0.0.1:3000/light/off
-```
-
-**Toggle a light**
-
-```console
-curl -X PUT 127.0.0.1:3000/light/toggle
-```
-
-At the server startup, an initial message signalling its effective execution and
-port number is printed.
-
-Before an action is performed on a device, a message with the REST API
-kind which triggers it is printed.
-
-```
-Starting the Ascot server (port 3000)…
-Performing the REST API (PUT)…
-```
+In `ascot-axum/examples` there are some implementation examples.

--- a/ascot-axum/Cargo.toml
+++ b/ascot-axum/Cargo.toml
@@ -25,3 +25,6 @@ default = ["mdns-sd-service"]
 
 # Services
 mdns-sd-service = ["dep:mdns-sd", "dep:gethostname", "dep:if-addrs"]
+
+[workspace]
+members = ["examples/fridge", "examples/light"]

--- a/ascot-axum/examples/fridge/Cargo.toml
+++ b/ascot-axum/examples/fridge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ascot-axum-firmware"
+name = "fridge"
 version = "0.1.0"
 edition = "2021"
 
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-lock = "3.3.0"
-ascot-axum = { version = "0.1.0", path = "../ascot-axum" }
-ascot-library = { version = "0.1.0", path = "../" }
+ascot-library = { version = "0.1.0", path = "../../../" }
+ascot-axum = { version = "0.1.0", path = "../../" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/ascot-axum/examples/fridge/README.md
+++ b/ascot-axum/examples/fridge/README.md
@@ -1,0 +1,45 @@
+# Fridge
+
+## Building
+
+Run the command
+
+```console
+cargo build
+```
+
+## Running the server
+
+The server runs on `localhost` and listens to port `3000`. To make it run:
+
+```console
+cargo run
+```
+
+## REST API examples
+
+Through `curl` or a web browser, it is possible to call the APIs which perform
+some actions on a device.
+
+**Increase temperature**
+
+```console
+curl -X PUT 127.0.0.1:3000/fridge/increase-temperature/1.0
+```
+
+```console
+curl -X POST 127.0.0.1:3000/fridge/increase-temperature/1.0
+```
+
+**Decrease temperature**
+
+```console
+curl -X PUT 127.0.0.1:3000/fridge/decrease-temperature/1.0
+```
+
+At the server startup, an initial message signalling its effective execution and
+port number is printed.
+
+```
+Starting the Ascot server at 0.0.0.0:3000
+```

--- a/ascot-axum/examples/fridge/src/dummy_fridge.rs
+++ b/ascot-axum/examples/fridge/src/dummy_fridge.rs
@@ -1,0 +1,26 @@
+#[derive(Clone)]
+pub(crate) struct DummyFridge {
+    pub(crate) temperature: f64,
+}
+
+impl Default for DummyFridge {
+    fn default() -> Self {
+        Self::init(2.0)
+    }
+}
+
+impl DummyFridge {
+    pub(crate) const fn init(temperature: f64) -> Self {
+        Self { temperature }
+    }
+
+    pub(crate) fn increase_temperature(&mut self, increment: f64) {
+        self.temperature += increment;
+        println!("Run increase temperature with increment={increment}");
+    }
+
+    pub(crate) fn decrease_temperature(&mut self, decrement: f64) {
+        self.temperature -= decrement;
+        println!("Run decrease temperature with decrement={decrement}");
+    }
+}

--- a/ascot-axum/examples/fridge/src/main.rs
+++ b/ascot-axum/examples/fridge/src/main.rs
@@ -1,0 +1,141 @@
+extern crate alloc;
+
+mod dummy_fridge;
+
+use alloc::sync::Arc;
+
+use ascot_axum::devices::fridge::Fridge;
+use async_lock::Mutex;
+use serde::{Deserialize, Serialize};
+
+// Library.
+use ascot_library::hazards::Hazard;
+use ascot_library::input::Input;
+use ascot_library::route::Route;
+
+// Miscellaneous.
+use ascot_axum::error::Error;
+use ascot_axum::service::ServiceBuilder;
+
+// Device.
+use ascot_axum::extract::{Extension, Json, Path};
+
+use ascot_axum::device::{DeviceAction, DeviceError, DevicePayload};
+
+// Server.
+use ascot_axum::server::AscotServer;
+
+// Fake fridge implementation
+use dummy_fridge::DummyFridge;
+
+#[derive(Clone, Default)]
+struct DeviceState(Arc<Mutex<DummyFridge>>);
+
+impl DeviceState {
+    fn new(fridge: DummyFridge) -> Self {
+        Self(Arc::new(Mutex::new(fridge)))
+    }
+}
+
+impl core::ops::Deref for DeviceState {
+    type Target = Arc<Mutex<DummyFridge>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl core::ops::DerefMut for DeviceState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[derive(Serialize)]
+struct ChangeTempResponse {
+    temperature: f64,
+}
+
+async fn increase_temperature(
+    Path(increment): Path<f64>,
+    Extension(state): Extension<DeviceState>,
+) -> Result<DevicePayload, DeviceError> {
+    let mut fridge = state.lock().await;
+    fridge.increase_temperature(increment);
+
+    DevicePayload::new(ChangeTempResponse {
+        temperature: fridge.temperature,
+    })
+}
+
+#[derive(Deserialize)]
+struct Inputs {
+    increment: f64,
+}
+
+async fn increase_temp_post(
+    Extension(state): Extension<DeviceState>,
+    Json(inputs): Json<Inputs>,
+) -> Result<DevicePayload, DeviceError> {
+    let mut fridge = state.lock().await;
+    fridge.increase_temperature(inputs.increment);
+
+    DevicePayload::new(ChangeTempResponse {
+        temperature: fridge.temperature
+    })
+}
+
+async fn decrease_temperature(
+    Path(decrement): Path<f64>,
+    Extension(state): Extension<DeviceState>,
+) -> Result<DevicePayload, DeviceError> {
+    let mut fridge = state.lock().await;
+    fridge.decrease_temperature(decrement);
+
+    DevicePayload::new(ChangeTempResponse {
+        temperature: fridge.temperature,
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Configuration for the `PUT` increase temperature route.
+    let increase_temp_config = Route::put("/increase-temperature")
+        .description("Increase temperature.")
+        .input(Input::rangef64("increment", (1., 4., 0.1, 2.)));
+
+    // Configuration for the `POST` increase temperature route.
+    let increase_temp_post_config = Route::post("/increase-temperature")
+        .description("Increase temperature.")
+        .input(Input::rangef64("increment", (1., 4., 0.1, 2.)));
+
+    // Configuration for the `PUT` decrease temperature route.
+    let decrease_temp_config = Route::put("/decrease-temperature")
+        .description("Decrease temperature.")
+        .input(Input::rangef64("decrement", (1., 4., 0.1, 2.)));
+
+    // A fridge device which is going to be run on the server.
+    let device = Fridge::new()
+        .increase_temperature(DeviceAction::with_hazards(
+            increase_temp_config,
+            increase_temperature,
+            &[Hazard::ElectricEnergyConsumption, Hazard::SpoiledFood],
+        ))?
+        .decrease_temperature(DeviceAction::with_hazards(
+            decrease_temp_config,
+            decrease_temperature,
+            &[Hazard::ElectricEnergyConsumption],
+        ))?
+        .add_action(DeviceAction::no_hazards(
+            increase_temp_post_config,
+            increase_temp_post,
+        ))?
+        .state(DeviceState::new(DummyFridge::default()))
+        .build()?;
+
+    // Run a discovery service and the device on the server.
+    AscotServer::new(device)
+        .run_service(ServiceBuilder::new("mdns-sd"))?
+        .run()
+        .await
+}

--- a/ascot-axum/examples/light/Cargo.toml
+++ b/ascot-axum/examples/light/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "light"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-lock = "3.3.0"
+ascot-library = { version = "0.1.0", path = "../../../" }
+ascot-axum = { version = "0.1.0", path = "../../" }
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["full"] }

--- a/ascot-axum/examples/light/README.md
+++ b/ascot-axum/examples/light/README.md
@@ -1,0 +1,51 @@
+# Light
+
+## Building
+
+Run the command
+
+```console
+cargo build
+```
+
+## Running the server
+
+The server runs on `localhost` and listens to port `3000`. To make it run:
+
+```console
+cargo run
+```
+
+## REST API examples
+
+Through `curl` or a web browser, it is possible to call the APIs which perform
+some actions on a device.
+
+**Turn a light on**
+
+```console
+curl -X PUT 127.0.0.1:3000/light/on/4.0/true
+```
+
+```console
+curl -X POST 127.0.0.1:3000/light/on/4.0/true
+```
+
+**Turn a light off**
+
+```console
+curl -X PUT 127.0.0.1:3000/light/off
+```
+
+**Toggle a light**
+
+```console
+curl -X PUT 127.0.0.1:3000/light/toggle
+```
+
+At the server startup, an initial message signalling its effective execution and
+port number is printed.
+
+```
+Starting the Ascot server at 0.0.0.0:3000
+```

--- a/ascot-axum/examples/light/src/dummy_light.rs
+++ b/ascot-axum/examples/light/src/dummy_light.rs
@@ -22,15 +22,15 @@ impl DummyLight {
         self.brightness = brightness;
         self.save_energy = save_energy;
         println!(
-                "Dummy light turn light on action with brightness={brightness} and save energy={save_energy}"
+                "Run turn light on with brightness={brightness} and save energy={save_energy}"
             );
     }
 
     pub(crate) fn turn_light_off(&self) {
-        println!("Run dummy light turn light off action");
+        println!("Run turn light off");
     }
 
     pub(crate) fn toggle(&self) {
-        println!("Run dummy light toggle action");
+        println!("Run light toggle");
     }
 }

--- a/ascot-axum/examples/light/src/main.rs
+++ b/ascot-axum/examples/light/src/main.rs
@@ -129,11 +129,11 @@ async fn main() -> Result<(), Error> {
         DeviceAction::with_hazard(light_on_config, turn_light_on, Hazard::FireHazard),
         DeviceAction::no_hazards(light_off_config, turn_light_off),
     )?
-    .add_action(DeviceAction::no_hazards(toggle_config, toggle))
+    .add_action(DeviceAction::no_hazards(toggle_config, toggle))?
     .add_action(DeviceAction::no_hazards(
         light_on_post_config,
         turn_light_on_post,
-    ))
+    ))?
     .state(DeviceState::new(DummyLight::default()))
     .build();
 

--- a/ascot-axum/src/devices/fridge.rs
+++ b/ascot-axum/src/devices/fridge.rs
@@ -1,0 +1,176 @@
+use ascot_library::device::DeviceKind;
+use ascot_library::hazards::Hazard;
+
+use axum::handler::Handler;
+use heapless::FnvIndexSet;
+
+use crate::device::{Device, DeviceAction};
+use crate::error::{Error, ErrorKind, Result};
+use crate::MAXIMUM_ELEMENTS;
+
+// The default main route for a fridge.
+const FRIDGE_MAIN_ROUTE: &str = "/fridge";
+
+// Mandatory actions hazards.
+const INCREASE_TEMPERATURE: &'static [Hazard] = &[Hazard::ElectricEnergyConsumption, Hazard::SpoiledFood];
+const DECREASE_TEMPERATURE: Hazard = Hazard::ElectricEnergyConsumption;
+
+// Allowed hazards.
+const ALLOWED_HAZARDS: &'static [Hazard] = &[Hazard::ElectricEnergyConsumption, Hazard::SpoiledFood];
+
+// Mandatory fridge actions.
+#[derive(Debug, PartialEq, Eq, Hash)]
+enum Actions {
+    IncreaseTemperature,
+    DecreaseTemperature,
+}
+
+/// A smart home fridge.
+///
+/// The default server main route for a fridge is `fridge`.
+///
+/// If a smart home needs more fridges, each fridge **MUST** provide a
+/// **different** main route in order to be registered.
+pub struct Fridge<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    // Main server route for fridge routes.
+    main_route: &'static str,
+    // Fridge state.
+    state: Option<S>,
+    // Device.
+    device: Device<S>,
+    // Mandatory fridge actions.
+    mandatory_actions: FnvIndexSet<Actions, MAXIMUM_ELEMENTS>,
+    // Allowed fridge hazards.
+    allowed_hazards: &'static [Hazard],
+}
+
+impl<S> Fridge<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    /// Creates a new [`Fridge`] instance.
+    pub fn new() -> Self {
+        // Create a new device.
+        let device = Device::new(DeviceKind::Fridge);
+
+        // Define mandatory actions.
+        let mut mandatory_actions = FnvIndexSet::new();
+        let _ = mandatory_actions.insert(Actions::IncreaseTemperature);
+        let _ = mandatory_actions.insert(Actions::DecreaseTemperature);
+
+        Self {
+            main_route: FRIDGE_MAIN_ROUTE,
+            device,
+            state: None,
+            mandatory_actions,
+            allowed_hazards: ALLOWED_HAZARDS,
+        }
+    }
+
+    /// Sets a new main route.
+    pub fn main_route(mut self, main_route: &'static str) -> Self {
+        self.main_route = main_route;
+        self
+    }
+
+    /// Adds increase temperature action for a [`Fridge`].
+    pub fn increase_temperature<H, T>(
+        mut self,
+        increase_temperature: DeviceAction<H, T>,
+    ) -> Result<Self>
+    where
+        H: Handler<T, ()>,
+        T: 'static,
+    {
+        // Raise an error whether increase_temperature does not contain
+        // electric energy consumption or spoiled food hazards.
+        if increase_temperature.miss_hazards(INCREASE_TEMPERATURE) {
+            return Err(Error::new(
+                ErrorKind::Fridge,
+                "No electric energy consumption or spoiled food hazards for the `increase_temperature` route",
+            ));
+        }
+
+        self.device = self.device.add_action(increase_temperature);
+
+        // Remove increase_temperature action from the list of actions to set.
+        self.mandatory_actions.remove(&Actions::IncreaseTemperature);
+
+        Ok(self)
+    }
+
+    /// Adds decrease temperature action for a [`Fridge`].
+    pub fn decrease_temperature<H, T>(
+        mut self,
+        decrease_temperature: DeviceAction<H, T>,
+    ) -> Result<Self>
+    where
+        H: Handler<T, ()>,
+        T: 'static,
+    {
+        // Raise an error whether decrease_temperature does not contain
+        // electric energy consumption hazard.
+        if decrease_temperature.miss_hazard(DECREASE_TEMPERATURE) {
+            return Err(Error::new(
+                ErrorKind::Fridge,
+                "No electric energy consumption hazard for the `decrease_temperature` route",
+            ));
+        }
+
+        self.device = self.device.add_action(decrease_temperature);
+
+        // Remove decrease_temperature action from the list of actions to set.
+        self.mandatory_actions.remove(&Actions::DecreaseTemperature);
+
+        Ok(self)
+    }
+
+    /// Adds an additional action for a [`Fridge`].
+    pub fn add_action<H, T>(mut self, fridge_action: DeviceAction<H, T>) -> Result<Self>
+    where
+        H: Handler<T, ()>,
+        T: 'static,
+    {
+        // Return an error if action hazards are not a subset of allowed hazards.
+        for hazard in fridge_action.hazards.iter() {
+            if !self.allowed_hazards.contains(hazard) {
+                return Err(Error::new(
+                    ErrorKind::Fridge,
+                    format!("{hazard} hazard is not allowed for fridge"),
+                ));
+            }
+        }
+
+        self.device = self.device.add_action(fridge_action);
+
+        Ok(self)
+    }
+
+    /// Sets a state for a [`Fridge`].
+    pub fn state(mut self, state: S) -> Self {
+        self.state = Some(state);
+        self
+    }
+
+    /// Builds a new [`Device`].
+    pub fn build(self) -> Result<Device<S>> {
+        // Return an error if not all mandatory actions are set.
+        if !self.mandatory_actions.is_empty() {
+            return Err(Error::new(
+                ErrorKind::Fridge,
+                format!(
+                    "The following mandatory actions are not set: {:?}",
+                    self.mandatory_actions
+                ),
+            ));
+        };
+
+        let mut device = self.device.main_route(self.main_route).finalize();
+        device.state = self.state;
+
+        Ok(device)
+    }
+}

--- a/ascot-axum/src/devices/mod.rs
+++ b/ascot-axum/src/devices/mod.rs
@@ -1,1 +1,2 @@
 pub mod light;
+pub mod fridge;

--- a/ascot-axum/src/error.rs
+++ b/ascot-axum/src/error.rs
@@ -13,6 +13,8 @@ pub enum ErrorKind {
     AscotLibrary,
     /// Light error.
     Light,
+    /// Fridge error.
+    Fridge,
 }
 
 impl ErrorKind {
@@ -23,6 +25,7 @@ impl ErrorKind {
             ErrorKind::Serialization => "serialization",
             ErrorKind::AscotLibrary => "Ascot library error",
             ErrorKind::Light => "light error",
+            ErrorKind::Fridge => "fridge error",
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -102,6 +102,8 @@ pub struct DeviceData<'a> {
 pub enum DeviceKind {
     /// Light.
     Light,
+    /// Fridge.
+    Fridge,
 }
 
 /// A trait to serialize device data.

--- a/src/hazards.rs
+++ b/src/hazards.rs
@@ -89,10 +89,50 @@ impl<'a> HazardsData<'a> {
 /// All possible hazards for a device task.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Hazard {
-    /// A fire hazard can destroy a smart home.
+    /// The execution may release toxic gases.
+    AirPoisoning,
+    /// The execution may cause oxygen deficiency by gaseous substances.
+    Asphyxia,
+    /// The execution authorises the app to record and save a video with audio on persistent storage.
+    AudioVideoRecordAndStore,
+    /// The execution authorises the app to obtain a video stream with audio.
+    AudioVideoStream,
+    /// The execution enables a device that consumes electricity.
+    ElectricEnergyConsumption,
+    /// The execution may cause an explosion.
+    Explosion,
+    /// The execution may cause fire.
     FireHazard,
-    /// The device consumes lots of energy.
-    EnergyConsumption,
+    /// The execution enables a device that consumes gas.
+    GasConsumption,
+    /// The execution authorises the app to get and save information about the app's energy impact on the device the app runs on.
+    LogEnergyConsumption,
+    /// The execution authorises the app to get and save information about the app's duration of use.
+    LogUsageTime,
+    /// The execution authorises the app to use payment information and make a periodic payment.
+    PaySubscriptionFee,
+    /// The execution may cause an interruption in the supply of electricity.
+    PowerOutage,
+    /// The execution may lead to exposure to high voltages.
+    PowerSurge,
+    /// The execution authorises the app to get and save user inputs.
+    RecordIssuedCommands,
+    /// The execution authorises the app to get and save information about the user's preferences.
+    RecordUserPreferences,
+    /// The execution authorises the app to use payment information and make a payment transaction.
+    SpendMoney,
+    /// The execution may lead to rotten food.
+    SpoiledFood,
+    /// The execution authorises the app to read the display output and take screenshots of it.
+    TakeDeviceScreenshots,
+    /// The execution authorises the app to use a camera and take photos.
+    TakePictures,
+    /// The execution disables a protection mechanism and unauthorised individuals may physically enter home.
+    UnauthorisedPhysicalAccess,
+    /// The execution enables a device that consumes water.
+    WaterConsumption,
+    /// The execution allows water usage which may lead to flood.
+    WaterFlooding,
 }
 
 impl core::fmt::Display for Hazard {
@@ -105,16 +145,56 @@ impl Hazard {
     /// Returns an [`Hazard`] name.
     pub const fn name(&self) -> &'static str {
         match self {
+            Self::AirPoisoning => "Air Poisoning",
+            Self::Asphyxia => "Asphyxia",
+            Self::AudioVideoRecordAndStore => "Audio Video Record And Store",
+            Self::AudioVideoStream => "Audio Video Stream",
+            Self::ElectricEnergyConsumption => "Electric Energy Consumption",
+            Self::Explosion => "Explosion",
             Self::FireHazard => "Fire Hazard",
-            Self::EnergyConsumption => "Energy Consumption",
+            Self::GasConsumption => "Gas Consumption",
+            Self::LogEnergyConsumption => "Log Energy Consumption",
+            Self::LogUsageTime => "Log Usage Time",
+            Self::PaySubscriptionFee => "Pay Subscription Fee",
+            Self::PowerOutage => "Power Outage",
+            Self::PowerSurge => "Power Surge",
+            Self::RecordIssuedCommands => "Record Issued Commands",
+            Self::RecordUserPreferences => "Record User Preferences",
+            Self::SpendMoney => "Spend Money",
+            Self::SpoiledFood => "Spoiled Food",
+            Self::TakeDeviceScreenshots => "Take Device Screenshots",
+            Self::TakePictures => "Take Pictures",
+            Self::UnauthorisedPhysicalAccess => "Unauthorised Physical Access",
+            Self::WaterConsumption => "Water Consumption",
+            Self::WaterFlooding => "Water Flooding",
         }
     }
 
     /// Returns an [`Hazard`] description.
     pub const fn description(&self) -> &'static str {
         match self {
-            Self::FireHazard => "A fire hazard can destroy a smart home.",
-            Self::EnergyConsumption => "The device consumes lots of energy.",
+            Self::AirPoisoning => "The execution may release toxic gases.",
+            Self::Asphyxia => "The execution may cause oxygen deficiency by gaseous substances.",
+            Self::AudioVideoRecordAndStore => "The execution authorises the app to record and save a video with audio on persistent storage.",
+            Self::AudioVideoStream => "The execution authorises the app to obtain a video stream with audio.",
+            Self::ElectricEnergyConsumption => "The execution enables a device that consumes electricity.",
+            Self::Explosion => "The execution may cause an explosion.",
+            Self::FireHazard => "The execution may cause fire.",
+            Self::GasConsumption => "The execution enables a device that consumes gas.",
+            Self::LogEnergyConsumption => "The execution authorises the app to get and save information about the app's energy impact on the device the app runs on.",
+            Self::LogUsageTime => "The execution authorises the app to get and save information about the app's duration of use.",
+            Self::PaySubscriptionFee => "The execution authorises the app to use payment information and make a periodic payment.",
+            Self::PowerOutage => "The execution may cause an interruption in the supply of electricity.",
+            Self::PowerSurge => "The execution may lead to exposure to high voltages.",
+            Self::RecordIssuedCommands => "The execution authorises the app to get and save user inputs.",
+            Self::RecordUserPreferences => "The execution authorises the app to get and save information about the user's preferences.",
+            Self::SpendMoney => "The execution authorises the app to use payment information and make a payment transaction.",
+            Self::SpoiledFood => "The execution may lead to rotten food.",
+            Self::TakeDeviceScreenshots => "The execution authorises the app to read the display output and take screenshots of it.",
+            Self::TakePictures => "The execution authorises the app to use a camera and take photos.",
+            Self::UnauthorisedPhysicalAccess => "The execution disables a protection mechanism and unauthorised individuals may physically enter home.",
+            Self::WaterConsumption => "The execution enables a device that consumes water.",
+            Self::WaterFlooding => "The execution allows water usage which may lead to flood.",
         }
     }
 
@@ -123,16 +203,56 @@ impl Hazard {
     /// An hazard **must** be associated with **only** one category.
     pub const fn category(&self) -> Category {
         match self {
+            Self::AirPoisoning => Category::Safety,
+            Self::Asphyxia => Category::Safety,
+            Self::AudioVideoRecordAndStore => Category::Privacy,
+            Self::AudioVideoStream => Category::Privacy,
+            Self::ElectricEnergyConsumption => Category::Financial,
+            Self::Explosion => Category::Safety,
             Self::FireHazard => Category::Safety,
-            Self::EnergyConsumption => Category::Financial,
+            Self::GasConsumption => Category::Financial,
+            Self::LogEnergyConsumption => Category::Privacy,
+            Self::LogUsageTime => Category::Privacy,
+            Self::PaySubscriptionFee => Category::Financial,
+            Self::PowerOutage => Category::Safety,
+            Self::PowerSurge => Category::Safety,
+            Self::RecordIssuedCommands => Category::Privacy,
+            Self::RecordUserPreferences => Category::Privacy,
+            Self::SpendMoney => Category::Financial,
+            Self::SpoiledFood => Category::Safety,
+            Self::TakeDeviceScreenshots => Category::Privacy,
+            Self::TakePictures => Category::Privacy,
+            Self::UnauthorisedPhysicalAccess => Category::Safety,
+            Self::WaterConsumption => Category::Financial,
+            Self::WaterFlooding => Category::Safety,
         }
     }
 
     /// Returns the identifier associated with an [`Hazard`].
     pub const fn id(&self) -> u16 {
         match self {
-            Self::FireHazard => 0,
-            Self::EnergyConsumption => 1,
+            Self::AirPoisoning => 0,
+            Self::Asphyxia => 1,
+            Self::AudioVideoRecordAndStore => 2,
+            Self::AudioVideoStream => 3,
+            Self::ElectricEnergyConsumption => 4,
+            Self::Explosion => 5,
+            Self::FireHazard => 6,
+            Self::GasConsumption => 7,
+            Self::LogEnergyConsumption => 8,
+            Self::LogUsageTime => 9,
+            Self::PaySubscriptionFee => 10,
+            Self::PowerOutage => 11,
+            Self::PowerSurge => 12,
+            Self::RecordIssuedCommands => 13,
+            Self::RecordUserPreferences => 14,
+            Self::SpendMoney => 15,
+            Self::SpoiledFood => 16,
+            Self::TakeDeviceScreenshots => 17,
+            Self::TakePictures => 18,
+            Self::UnauthorisedPhysicalAccess => 19,
+            Self::WaterConsumption => 20,
+            Self::WaterFlooding => 21,
         }
     }
 
@@ -142,8 +262,28 @@ impl Hazard {
     /// it is not correct.
     pub const fn from_id(id: u16) -> Option<Self> {
         match id {
-            0 => Some(Self::FireHazard),
-            1 => Some(Self::EnergyConsumption),
+            0 => Some(Self::AirPoisoning),
+            1 => Some(Self::Asphyxia),
+            2 => Some(Self::AudioVideoRecordAndStore),
+            3 => Some(Self::AudioVideoStream),
+            4 => Some(Self::ElectricEnergyConsumption),
+            5 => Some(Self::Explosion),
+            6 => Some(Self::FireHazard),
+            7 => Some(Self::GasConsumption),
+            8 => Some(Self::LogEnergyConsumption),
+            9 => Some(Self::LogUsageTime),
+            10 => Some(Self::PaySubscriptionFee),
+            11 => Some(Self::PowerOutage),
+            12 => Some(Self::PowerSurge),
+            13 => Some(Self::RecordIssuedCommands),
+            14 => Some(Self::RecordUserPreferences),
+            15 => Some(Self::SpendMoney),
+            16 => Some(Self::SpoiledFood),
+            17 => Some(Self::TakeDeviceScreenshots),
+            18 => Some(Self::TakePictures),
+            19 => Some(Self::UnauthorisedPhysicalAccess),
+            20 => Some(Self::WaterConsumption),
+            21 => Some(Self::WaterFlooding),
             _ => None,
         }
     }
@@ -208,10 +348,12 @@ impl<'a> core::cmp::PartialEq for CategoryData<'a> {
 /// Hazard categories.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
 pub enum Category {
-    /// All the safety-related hazards.
-    Safety,
-    /// All the financial-related hazards.
+    /// Category which includes all the financial-related hazards.
     Financial,
+    /// Category which includes all the privacy-related hazards.
+    Privacy,
+    /// Category which includes all the safety-related hazards.
+    Safety,
 }
 
 impl core::fmt::Display for Category {
@@ -224,24 +366,52 @@ impl Category {
     /// Returns a [`Category`] name.
     pub const fn name(&self) -> &'static str {
         match self {
-            Self::Safety => "Safety",
             Self::Financial => "Financial",
+            Self::Privacy => "Privacy",
+            Self::Safety => "Safety",
         }
     }
 
     /// Returns a [`Category`] description.
     pub const fn description(&self) -> &'static str {
         match self {
-            Self::Safety => "All the safety-related hazards.",
-            Self::Financial => "All the financial-related hazards.",
+            Self::Financial => "Category which includes all the financial-related hazards.",
+            Self::Privacy => "Category which includes all the privacy-related hazards.",
+            Self::Safety => "Category which includes all the safety-related hazards.",
         }
     }
 
     /// Returns all [`Hazard`]s associated with a [`Category`].
     pub const fn hazards(&self) -> &[Hazard] {
         match self {
-            Self::Safety => &[Hazard::FireHazard],
-            Self::Financial => &[Hazard::EnergyConsumption],
+            Self::Financial => &[
+                Hazard::ElectricEnergyConsumption,
+                Hazard::GasConsumption,
+                Hazard::PaySubscriptionFee,
+                Hazard::SpendMoney,
+                Hazard::WaterConsumption,
+            ],
+            Self::Privacy => &[
+                Hazard::AudioVideoRecordAndStore,
+                Hazard::AudioVideoStream,
+                Hazard::LogEnergyConsumption,
+                Hazard::LogUsageTime,
+                Hazard::RecordIssuedCommands,
+                Hazard::RecordUserPreferences,
+                Hazard::TakeDeviceScreenshots,
+                Hazard::TakePictures,
+            ],
+            Self::Safety => &[
+                Hazard::AirPoisoning,
+                Hazard::Asphyxia,
+                Hazard::Explosion,
+                Hazard::FireHazard,
+                Hazard::PowerOutage,
+                Hazard::PowerSurge,
+                Hazard::SpoiledFood,
+                Hazard::UnauthorisedPhysicalAccess,
+                Hazard::WaterFlooding,
+            ],
         }
     }
 }


### PR DESCRIPTION
This pr:
- Updates `ascot-axum` **light** device by adding allowed hazards.
- Adds an `ascot-axum` **fridge** device, in order to have an example of device for which mandatory actions are defined via method calls.
- Moves implementation examples in `ascot-axum/examples`.