### PR TITLE
esp32c3: Update build files for examples

### DIFF
--- a/crates/tosca-esp32c3/examples/light-with-events/build.rs
+++ b/crates/tosca-esp32c3/examples/light-with-events/build.rs
@@ -16,7 +16,7 @@ fn main() {
     // Checks whether device configuration exists
     assert!(
         cfg.exists(),
-        "A `cfg.toml` file with Wi-Fi credentials is required! Use `cfg.toml.example` as a template."
+        "A `cfg.toml` file with Wi-Fi credentials and broker configuration is required! Use `cfg.toml.example` as a template."
     );
 
     let device_config = DEVICE_CONFIG;
@@ -53,12 +53,10 @@ fn linker_be_nice() {
                     eprintln!("💡 Is the linker script `linkall.x` missing?");
                     eprintln!();
                 }
-                "esp_wifi_preempt_enable"
-                | "esp_wifi_preempt_yield_task"
-                | "esp_wifi_preempt_task_create" => {
+                "esp_rtos_initialized" | "esp_rtos_yield_task" | "esp_rtos_task_create" => {
                     eprintln!();
                     eprintln!(
-                        "💡 `esp-wifi` has no scheduler enabled. Make sure you have the `builtin-scheduler` feature enabled, or that you provide an external scheduler."
+                        "💡 `esp-radio` has no scheduler enabled. Make sure you have initialized `esp-rtos` or provided an external scheduler."
                     );
                     eprintln!();
                 }

--- a/crates/tosca-esp32c3/examples/light-with-state/build.rs
+++ b/crates/tosca-esp32c3/examples/light-with-state/build.rs
@@ -46,12 +46,10 @@ fn linker_be_nice() {
                     eprintln!("💡 Is the linker script `linkall.x` missing?");
                     eprintln!();
                 }
-                "esp_wifi_preempt_enable"
-                | "esp_wifi_preempt_yield_task"
-                | "esp_wifi_preempt_task_create" => {
+                "esp_rtos_initialized" | "esp_rtos_yield_task" | "esp_rtos_task_create" => {
                     eprintln!();
                     eprintln!(
-                        "💡 `esp-wifi` has no scheduler enabled. Make sure you have the `builtin-scheduler` feature enabled, or that you provide an external scheduler."
+                        "💡 `esp-radio` has no scheduler enabled. Make sure you have initialized `esp-rtos` or provided an external scheduler."
                     );
                     eprintln!();
                 }

--- a/crates/tosca-esp32c3/examples/light/build.rs
+++ b/crates/tosca-esp32c3/examples/light/build.rs
@@ -46,12 +46,10 @@ fn linker_be_nice() {
                     eprintln!("💡 Is the linker script `linkall.x` missing?");
                     eprintln!();
                 }
-                "esp_wifi_preempt_enable"
-                | "esp_wifi_preempt_yield_task"
-                | "esp_wifi_preempt_task_create" => {
+                "esp_rtos_initialized" | "esp_rtos_yield_task" | "esp_rtos_task_create" => {
                     eprintln!();
                     eprintln!(
-                        "💡 `esp-wifi` has no scheduler enabled. Make sure you have the `builtin-scheduler` feature enabled, or that you provide an external scheduler."
+                        "💡 `esp-radio` has no scheduler enabled. Make sure you have initialized `esp-rtos` or provided an external scheduler."
                     );
                     eprintln!();
                 }


### PR DESCRIPTION
Update `tosca-esp32c3` example build files to reflect dependency updates from #29.