### PR TITLE
esp32c3: Fix u32 range parameters

### DIFF
--- a/crates/tosca-esp32c3/src/parameters.rs
+++ b/crates/tosca-esp32c3/src/parameters.rs
@@ -257,9 +257,13 @@ impl ParametersPayloads {
     #[inline]
     pub fn u32(&mut self, name: &'static str) -> Result<U32Payload, ErrorResponse> {
         self.insert(name, |payload| match (payload.value, payload.kind) {
-            (ParameterValue::U32(v), ParameterKind::U32 { default, min, max }) => {
-                Ok(U32Payload::new(v, default, min, max))
-            }
+            (
+                ParameterValue::U32(v),
+                ParameterKind::U32 { default, min, max }
+                | ParameterKind::RangeU32 {
+                    default, min, max, ..
+                },
+            ) => Ok(U32Payload::new(v, default, min, max)),
             _ => Err(invalid_data(&format!("`{name}` is not a `u32` kind"))),
         })
     }


### PR DESCRIPTION
Fixes the handling of `u32` range parameters for esp32c3.
The previous PR (#43 ) added the feature but missed part of the implementation in `parameters.rs`, causing `RangeU32` parameters to fail. This completes the implementation so everything works as intended.