### PR TITLE
Add a semantic versioning check

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,27 @@
+name: semver
+
+on:
+  schedule:
+    - cron: '0 21 * * THU' # Run every Thursday at 21:00 (UTC)
+  push:
+    tags:
+      - 'v*.*.*' # Run when a new version is being published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semver-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: Check semantic versioning violations
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          # cargo-semver-checks uses `all-features` by default, but `tosca`
+          # publishes on crates.io with `default-features`
+          feature-group: default-features


### PR DESCRIPTION
Add a semantic versioning check to the CI pipeline to prevent API breakages.