### PR TITLE
Add DeviceKindTrait and implement for DeviceKind

### DIFF
--- a/crates/tosca/src/device.rs
+++ b/crates/tosca/src/device.rs
@@ -44,8 +44,8 @@ pub enum DeviceKind {
     Light,
 }
 
-impl DeviceKind {
-    const fn description(self) -> &'static str {
+impl DeviceKindTrait for DeviceKind {
+    fn name(&self) -> &'static str {
         match self {
             Self::Unknown => "Unknown",
             Self::Light => "Light",
@@ -55,7 +55,7 @@ impl DeviceKind {
 
 impl core::fmt::Display for DeviceKind {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "{}", self.name())
     }
 }
 


### PR DESCRIPTION
This PR implements the first part of the improvements discussed in #112.

It introduces a new `DeviceKindTrait` with `name()` and `topic_prefix()` methods. The existing `DeviceKind` enum now implements this trait, replacing the previous `description()` method. The `Display` implementation has also been updated to use `name()`.

No functional changes are intended, and this PR should not introduce any breaking changes.