### PR TITLE
tosca-esp32c3: Add recursion limit to examples

### DIFF
--- a/crates/tosca-esp32c3/examples/light-with-events/src/main.rs
+++ b/crates/tosca-esp32c3/examples/light-with-events/src/main.rs
@@ -1,5 +1,8 @@
 #![no_std]
 #![no_main]
+// FIXME: Work around Rust 1.94 query-depth regression with deeply nested async futures.
+// Remove once the upstream issue is fixed: https://github.com/rust-lang/rust/issues/152942
+#![recursion_limit = "256"]
 #![deny(
     clippy::mem_forget,
     reason = "mem::forget is generally not safe to do with esp_hal types, especially those \

--- a/crates/tosca-esp32c3/examples/light-with-state/src/main.rs
+++ b/crates/tosca-esp32c3/examples/light-with-state/src/main.rs
@@ -1,5 +1,8 @@
 #![no_std]
 #![no_main]
+// FIXME: Work around Rust 1.94 query-depth regression with deeply nested async futures.
+// Remove once the upstream issue is fixed: https://github.com/rust-lang/rust/issues/152942
+#![recursion_limit = "256"]
 #![deny(
     clippy::mem_forget,
     reason = "mem::forget is generally not safe to do with esp_hal types, especially those \

--- a/crates/tosca-esp32c3/examples/light/src/main.rs
+++ b/crates/tosca-esp32c3/examples/light/src/main.rs
@@ -1,5 +1,8 @@
 #![no_std]
 #![no_main]
+// FIXME: Work around Rust 1.94 query-depth regression with deeply nested async futures.
+// Remove once the upstream issue is fixed: https://github.com/rust-lang/rust/issues/152942
+#![recursion_limit = "256"]
 #![deny(
     clippy::mem_forget,
     reason = "mem::forget is generally not safe to do with esp_hal types, especially those \


### PR DESCRIPTION
Add `#![recursion_limit = "256"]` to all examples to work around a
Rust 1.94 query-depth regression triggered by deeply nested async futures
during compilation.

Starting from Rust 1.94, `tosca-esp32c3` examples fail to compile during
`cargo clippy` with: `error: queries overflow the depth limit!`

This appears to be caused by a regression in the compiler's query system
when computing layouts for deeply nested async futures.

Increasing the example recursion limit resolves the issue and allows CI
to run clippy successfully again.

Related upstream issue:
https://github.com/rust-lang/rust/issues/152942