### PR TITLE
Enhance wifi and ethernet methods in `tosca`

### DIFF
--- a/crates/tosca/src/device.rs
+++ b/crates/tosca/src/device.rs
@@ -247,15 +247,15 @@ impl DeviceDescription {
 
     /// Sets the Wi-Fi MAC address.
     #[must_use]
-    pub const fn wifi_mac(mut self, wifi_mac: Option<[u8; 6]>) -> Self {
-        self.data.wifi_mac = wifi_mac;
+    pub const fn wifi_mac(mut self, wifi_mac: [u8; 6]) -> Self {
+        self.data.wifi_mac = Some(wifi_mac);
         self
     }
 
     /// Sets the Ethernet MAC address.
     #[must_use]
-    pub const fn ethernet_mac(mut self, ethernet_mac: Option<[u8; 6]>) -> Self {
-        self.data.ethernet_mac = ethernet_mac;
+    pub const fn ethernet_mac(mut self, ethernet_mac: [u8; 6]) -> Self {
+        self.data.ethernet_mac = Some(ethernet_mac);
         self
     }
 


### PR DESCRIPTION
It is no longer necessary to pass an `Option` when calling `wifi_mac` or `ethernet_mac`