### PR TITLE
Fix clippy lint in `os-ip-camera`

### DIFF
--- a/examples/os-ip-camera/src/info.rs
+++ b/examples/os-ip-camera/src/info.rs
@@ -95,7 +95,7 @@ pub(crate) async fn show_camera_info(
                         .collect::<Vec<(Resolution, Vec<u32>)>>();
 
                     // Sort formats by name
-                    formats.sort_by(|a, b| a.0.cmp(&b.0));
+                    formats.sort_by_key(|a| a.0);
 
                     // Show sorted formats.
                     let format_data = formats


### PR DESCRIPTION
Fix clippy lint in `os-ip-camera` example