### PR TITLE
Remove the `stream` feature from `tosca` 

### DIFF
--- a/crates/tosca-controller/Cargo.toml
+++ b/crates/tosca-controller/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [features]
 metadata = []
-stream = ["dep:futures-util", "tosca/stream"]
+stream = ["dep:futures-util"]
 default = ["metadata"]
 
 [dependencies]

--- a/crates/tosca-controller/src/request.rs
+++ b/crates/tosca-controller/src/request.rs
@@ -216,6 +216,13 @@ impl Request {
             ResponseKind::Ok => Response::OkBody(OkResponseParser::new(response)),
             ResponseKind::Serial => Response::SerialBody(SerialResponseParser::new(response)),
             ResponseKind::Info => Response::InfoBody(InfoResponseParser::new(response)),
+            #[cfg(not(feature = "stream"))]
+            ResponseKind::Stream => {
+                tracing::warn!(
+                    "Skipping stream response because the `stream` feature is not enabled."
+                );
+                Response::Skipped
+            }
             #[cfg(feature = "stream")]
             ResponseKind::Stream => {
                 Response::StreamBody(crate::response::StreamResponse::new(response))

--- a/crates/tosca-os/Cargo.toml
+++ b/crates/tosca-os/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-stream = ["dep:futures-core", "dep:tokio-util", "tosca/stream"]
+stream = ["dep:futures-core", "dep:tokio-util"]
 default = []
 
 [dependencies]

--- a/crates/tosca/Cargo.toml
+++ b/crates/tosca/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 workspace = true
 
 [features]
-stream = []
 deserialize = []
 default = ["deserialize"]
 

--- a/crates/tosca/src/response.rs
+++ b/crates/tosca/src/response.rs
@@ -26,7 +26,6 @@ pub enum ResponseKind {
     /// a device energy and economy information.
     Info,
     /// This response transmits a byte stream of data over the network.
-    #[cfg(feature = "stream")]
     Stream,
 }
 
@@ -36,7 +35,6 @@ impl core::fmt::Display for ResponseKind {
             Self::Ok => "Ok",
             Self::Serial => "Serial",
             Self::Info => "Info",
-            #[cfg(feature = "stream")]
             Self::Stream => "Stream",
         }
         .fmt(f)

--- a/examples/os-ip-camera/Cargo.toml
+++ b/examples/os-ip-camera/Cargo.toml
@@ -13,7 +13,6 @@ publish = false
 tosca.path = "../../crates/tosca"
 tosca.version = "0.1"
 tosca.default-features = false
-tosca.features = ["stream"]
 
 tosca-os.path = "../../crates/tosca-os"
 tosca-os.version = "0.1"


### PR DESCRIPTION
This `stream` feature should be defined only in the firmware and controller crates, which are responsible for implementing byte stream transmission and reception.
This also reduces the number of features in the `tosca` crate.