### PR TITLE
Remove `deserialize` from default features

### DIFF
--- a/crates/tosca/Cargo.toml
+++ b/crates/tosca/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [features]
 deserialize = []
-default = ["deserialize"]
+default = []
 
 [dependencies]
 hashbrown.workspace = true

--- a/examples/controller-events-receiver/Cargo.toml
+++ b/examples/controller-events-receiver/Cargo.toml
@@ -16,7 +16,6 @@ publish = false
 tosca.path = "../../crates/tosca"
 tosca.version = "0.1"
 tosca.default-features = false
-tosca.features = ["deserialize"]
 
 tosca-controller.path = "../../crates/tosca-controller"
 tosca-controller.version = "0.1"

--- a/examples/controller-events-sse-receiver/Cargo.toml
+++ b/examples/controller-events-sse-receiver/Cargo.toml
@@ -17,7 +17,6 @@ publish = false
 tosca.path = "../../crates/tosca"
 tosca.version = "0.1"
 tosca.default-features = false
-tosca.features = ["deserialize"]
 
 tosca-controller.path = "../../crates/tosca-controller"
 tosca-controller.version = "0.1"


### PR DESCRIPTION
The `deserialize` feature should be optional and explicitly enabled by developers. This avoids importing all `Deserialize` traits into a firmware when `default-features` option is not set to false.