### PR TITLE
tosca: add Camera device kind

### DIFF
--- a/crates/tosca-os/src/device.rs
+++ b/crates/tosca-os/src/device.rs
@@ -165,7 +165,6 @@ mod tests {
     #[test]
     fn sets_device_kind() {
         let device = Device::new().kind(&DeviceKind::Camera);
-
         assert!(device.description.data.kind.matches(&DeviceKind::Camera));
     }
 

--- a/crates/tosca-os/src/device.rs
+++ b/crates/tosca-os/src/device.rs
@@ -57,6 +57,13 @@ where
         Self::init(&DeviceKind::Unknown, state)
     }
 
+    /// Sets the device kind.
+    #[must_use]
+    pub fn kind<K: DeviceKindTrait>(mut self, kind: &K) -> Self {
+        self.description.data.kind = DeviceKindId::from(kind);
+        self
+    }
+
     /// Sets the main route.
     #[must_use]
     pub const fn main_route(mut self, main_route: &'static str) -> Self {
@@ -139,7 +146,7 @@ mod tests {
 
     use core::ops::{Deref, DerefMut};
 
-    use tosca::device::DeviceMetrics;
+    use tosca::device::{DeviceKind, DeviceMetrics};
     use tosca::energy::Energy;
     use tosca::route::Route;
 
@@ -154,6 +161,13 @@ mod tests {
     use crate::responses::serial::{SerialResponse, serial_stateful, serial_stateless};
 
     use super::Device;
+
+    #[test]
+    fn sets_device_kind() {
+        let device = Device::new().kind(&DeviceKind::Camera);
+
+        assert!(device.description.data.kind.matches(&DeviceKind::Camera));
+    }
 
     #[derive(Clone)]
     struct DeviceState<S>

--- a/crates/tosca/src/device.rs
+++ b/crates/tosca/src/device.rs
@@ -40,6 +40,8 @@ pub trait DeviceKindTrait {
 pub enum DeviceKind {
     /// Unknown.
     Unknown,
+    /// Camera.
+    Camera,
     /// Light.
     Light,
 }
@@ -48,6 +50,7 @@ impl DeviceKindTrait for DeviceKind {
     fn name(&self) -> &'static str {
         match self {
             Self::Unknown => "Unknown",
+            Self::Camera => "Camera",
             Self::Light => "Light",
         }
     }
@@ -291,7 +294,10 @@ mod tests {
     };
     use crate::{deserialize, serialize};
 
-    use super::{DeviceDescription, DeviceEnvironment, DeviceKind, DeviceKindId, DeviceMetrics};
+    use super::{
+        DeviceDescription, DeviceEnvironment, DeviceKind, DeviceKindId, DeviceKindTrait,
+        DeviceMetrics,
+    };
 
     fn energy() -> Energy {
         let energy_efficiencies =
@@ -326,12 +332,16 @@ mod tests {
 
     #[test]
     fn test_device_kind() {
-        for device_kind in &[DeviceKind::Unknown, DeviceKind::Light] {
+        for device_kind in &[DeviceKind::Unknown, DeviceKind::Camera, DeviceKind::Light] {
             assert_eq!(
                 deserialize::<DeviceKind>(serialize(device_kind)),
                 *device_kind
             );
         }
+
+        assert_eq!(serialize(DeviceKind::Camera), "Camera");
+        assert_eq!(DeviceKind::Camera.name(), "Camera");
+        assert!(DeviceKindId::new("Camera").matches(&DeviceKind::Camera));
     }
 
     #[test]

--- a/examples/os-ip-camera/src/main.rs
+++ b/examples/os-ip-camera/src/main.rs
@@ -6,6 +6,7 @@ mod stream;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 
+use tosca::device::DeviceKind;
 use tosca::hazards::Hazard;
 use tosca::parameters::Parameters;
 use tosca::route::Route;
@@ -381,6 +382,7 @@ async fn main() -> Result<(), Error> {
 
     // A camera device which is going to be run on the server.
     let device = Device::with_state(InternalState::new(camera))
+        .kind(&DeviceKind::Camera)
         .main_route("/camera")
         .route(stream_stateful(camera_stream_route, show_camera_stream))
         .route(serial_stateless(view_cameras_route, show_available_cameras))


### PR DESCRIPTION
## Summary

- add `DeviceKind::Camera` to the canonical device model
- expose the stable `Camera` name through `DeviceKindTrait`
- cover serialization, deserialization, and `DeviceKindId` matching

This keeps the existing externally tagged Serde representation intact: `Camera` serializes as the string `"Camera"`, while existing `Unknown` and `Light` values remain unchanged.

Closes #100.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -Dclippy::all -Dclippy::pedantic`
- `cargo test -p tosca --all-features`
- `CI=true cargo test`
- `CI=true cargo test --all-features`
- `cargo build`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`

An unconstrained local `cargo test` also exercised the suite, but four controller discovery tests require valid network MAC data on this host. They pass under the repository's documented CI mode (`CI=true`).